### PR TITLE
fix t3jquery class name

### DIFF
--- a/Classes/ViewHelpers/AddJQueryViewHelper.php
+++ b/Classes/ViewHelpers/AddJQueryViewHelper.php
@@ -64,7 +64,7 @@ class AddJQueryViewHelper extends AbstractTagBasedViewHelper {
 		}
 		// if t3jquery is loaded and the custom Library had been created
 		if (T3JQUERY === TRUE) {
-			tx_t3jquery::addJqJS();
+			\tx_t3jquery::addJqJS();
 
 		} else {
 			if ($altJQueryFile) {


### PR DESCRIPTION
without leading \ it gets the namespace prepended resulting in:
"PHP Fatal error:  Class 'SotaStudio\Flexslider\ViewHelpers\tx_t3jquery' not found" in FE
