### PR TITLE
Exchanged $ with jQuery to avoid conflicts

### DIFF
--- a/Resources/Private/Partials/JavaScriptRaw.html
+++ b/Resources/Private/Partials/JavaScriptRaw.html
@@ -1,4 +1,4 @@
-<![CDATA[ $(window).load(function() { ]]>
+<![CDATA[ jQuery(window).ready(function($) { ]]>
 	$('#fs-{f:if(condition: data.pi_flexform, then: data.uid, else: altUid)}.flexslider').flexslider(
     <![CDATA[{]]>
 		animation: "{settings.animation}",


### PR DESCRIPTION
In some cases where different JS-libraries are loaded too the slider crashes with the console error message:
"Uncaught TypeError: $(...).load is not a function"
This may be caused by a conflict with the $ from prototype.js. I had this case on a page using tt_news category menu which adds prototype.js after the flexslider's jquery - call and leads to this error.
Also I changed the jQuery.load() - function call with the jQuery.ready() to be sure the DOM is loaded and the accessed selector is available.
![image](https://cloud.githubusercontent.com/assets/1579715/7199714/322a05fe-e4f7-11e4-8788-bb9b2d89fde5.png)
